### PR TITLE
context を to_string() するときは各行を name でソートする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "combine",
  "glob",
  "home-dir",
+ "rand",
  "regex",
  "ulid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ clap = { version = "4.3.19", features = ["derive"] }
 home-dir = "0.1.0"
 glob = "0.3.1"
 ulid = "1.0.0"
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,5 @@
 mod default;
+mod display;
 
 use std::collections::HashMap;
 

--- a/src/context/display.rs
+++ b/src/context/display.rs
@@ -27,30 +27,36 @@ mod tests {
     use super::*;
     use crate::expression::Expr;
     use crate::function::Func;
+    use rand::seq::SliceRandom;
 
     #[test]
     fn test_display() {
-        let mut context = Context::new();
-        context.def(Func::new(
-            "i".into(),
-            vec!["x".into()],
-            Expr::Variable("x".into()),
-        ));
-        context.def(Func::new(
-            "l".into(),
-            vec!["x".into(), "y".into()],
-            Expr::Variable("x".into()),
-        ));
-        context.def(Func::new(
-            "K".into(),
-            vec!["x".into(), "y".into()],
-            Expr::Variable("x".into()),
-        ));
-        context.def(Func::new(
-            "k".into(),
-            vec!["x".into(), "y".into()],
-            Expr::Variable("x".into()),
-        ));
+        let mut funcs = [
+            Func::new("i".into(), vec!["x".into()], Expr::Variable("x".into())),
+            Func::new(
+                "k".into(),
+                vec!["x".into(), "y".into()],
+                Expr::Variable("x".into()),
+            ),
+            Func::new(
+                "K".into(),
+                vec!["x".into(), "y".into()],
+                Expr::Variable("x".into()),
+            ),
+            Func::new(
+                "l".into(),
+                vec!["x".into(), "y".into()],
+                Expr::Variable("x".into()),
+            ),
+        ];
+
+        // funcs を事前にシャッフルしてから Context を作る
+        // これによって Context の印字が Func の順序依存でないことを確かめる
+
+        let mut rng = rand::thread_rng();
+        funcs.shuffle(&mut rng);
+
+        let context = Context::from(funcs.to_vec());
 
         assert_eq!(
             format!("{}", context),

--- a/src/context/display.rs
+++ b/src/context/display.rs
@@ -1,0 +1,66 @@
+use crate::context::Context;
+use std::fmt::Display;
+
+impl Display for Context {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut context = self.0.iter().collect::<Vec<_>>();
+
+        context.sort_by(|l, r| {
+            let (l_name, r_name) = (l.0.as_ref(), r.0.as_ref());
+            l_name.cmp(r_name)
+        });
+
+        write!(
+            f,
+            "{}",
+            context
+                .iter()
+                .map(|(_, func)| func.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expression::Expr;
+    use crate::function::Func;
+
+    #[test]
+    fn test_display() {
+        let mut context = Context::new();
+        context.def(Func::new(
+            "i".into(),
+            vec!["x".into()],
+            Expr::Variable("x".into()),
+        ));
+        context.def(Func::new(
+            "l".into(),
+            vec!["x".into(), "y".into()],
+            Expr::Variable("x".into()),
+        ));
+        context.def(Func::new(
+            "K".into(),
+            vec!["x".into(), "y".into()],
+            Expr::Variable("x".into()),
+        ));
+        context.def(Func::new(
+            "k".into(),
+            vec!["x".into(), "y".into()],
+            Expr::Variable("x".into()),
+        ));
+
+        assert_eq!(
+            format!("{}", context),
+            "
+                ``Kxy = x\n\
+                `ix = x\n\
+                ``kxy = x\n\
+                ``lxy = x
+            "
+            .trim()
+        );
+    }
+}

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -41,6 +41,12 @@ impl std::fmt::Display for Ident {
     }
 }
 
+impl AsRef<str> for Ident {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 #[test]
 fn test_new_name() {
     let mut set: HashSet<Ident> = HashSet::new();


### PR DESCRIPTION
- Issues: https://github.com/todays-mitsui/rusty-tuber/issues/9

## 変更の背景

- Context を印字したときの Func の並び順が不可解で、なんかグチャっとしてた
- なぜなら Context は内部的に HashMap を使っていて、HashMap をイテレートしたときの順番はランダムだから
  - 素朴に実装すると Func の並び順は毎回ランダムになる
  - それは素朴すぎる
- なので name でソートしてから印字したい

## やったこと

- Context を印字するとき事前に name でソートする
  - 辞書順昇順